### PR TITLE
Don't Compile Tests and Datagen Automatically.

### DIFF
--- a/.github/actions/compile_GRHayL/action.yml
+++ b/.github/actions/compile_GRHayL/action.yml
@@ -42,6 +42,6 @@ runs:
       shell: bash
 
     - run: |
-        make
+        make tests datagen
         make install
       shell: bash

--- a/configure
+++ b/configure
@@ -784,10 +784,10 @@ if [ "$datagen" != "" ]; then
     printf "DGOBJS    = $dgobjs\n"      >> Makefile
     printf "DGEXEOBJS = $dgexeobjs\n\n" >> Makefile
 fi
-printf '\nall: grhayl tests datagen\n\t@echo "All done!"\n\n' >> Makefile
-printf 'grhayl: $(LIBS)\n\n'                          >> Makefile
-printf 'tests: $(TEXES)\n\n'                          >> Makefile
-printf 'datagen: $(DGEXES)\n\n'                       >> Makefile
+printf '\nall: grhayl\n\t@echo "All done!"\n\n'             >> Makefile
+printf 'grhayl: $(LIBS)\n\n'                                >> Makefile
+printf 'tests: grhayl $(TEXES)\n\t@echo "All done!"\n\n'    >> Makefile
+printf 'datagen: grhayl $(DGEXES)\n\t@echo "All done!"\n\n' >> Makefile
 if [ $silent -eq 0 ]; then
     printf '$(BUILDLIBSO): $(BUILDLIBSOV)\n'                                         >> Makefile
     printf '\trm -f $(BUILDLIBSO) && ln -s $(LIBSOV) $(BUILDLIBSO)\n\n'              >> Makefile


### PR DESCRIPTION
Added new configure script where tests and datagen executables are not automatically linked. The syntax
```sh
make
```
will simply compile the library. If you want to create the tests and datagen executables, then the new command is
```sh
make tests datagen
```