### PR TITLE
Fix for proper upload with codecov@v4

### DIFF
--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -48,5 +48,5 @@ runs:
       shell: bash
 
     - uses: codecov/codecov-action@v4
-      with:
+      env:
         token: codecov_token

--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -5,9 +5,6 @@ inputs:
     description: compiler for test
     required: true
     default: 'gcc'
-  codecov_token:
-    description: GitHub token for CodeCov
-    required: true
 
 runs:
   using: "composite"
@@ -47,6 +44,4 @@ runs:
         gcovr -r . --gcov-executable "llvm-cov-14 gcov" --keep
       shell: bash
 
-    - uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: codecov_token
+    - uses: codecov/codecov-action@v3

--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -49,4 +49,4 @@ runs:
 
     - uses: codecov/codecov-action@v4
       env:
-        token: codecov_token
+        CODECOV_TOKEN: codecov_token

--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: compiler for test
     required: true
     default: 'gcc'
+  codecov_token:
+    description: GitHub token for CodeCov
+    required: true
 
 runs:
   using: "composite"
@@ -45,3 +48,5 @@ runs:
       shell: bash
 
     - uses: codecov/codecov-action@v4
+      with:
+        token: codecov_token

--- a/.github/workflows/github-actions-MacOS-gcc.yml
+++ b/.github/workflows/github-actions-MacOS-gcc.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -37,14 +37,13 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   c2p-routines:
     strategy:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -69,14 +68,13 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   c2p-failure:
     strategy:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -95,13 +93,12 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   tabulated-eos:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -122,13 +119,12 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   piecewise-polytrope-eos:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -147,13 +143,12 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   grhayl-core:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -175,14 +170,13 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   flux:
     strategy:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -207,14 +201,13 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   reconstruction:
     strategy:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENO5_reconstruction]
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -238,14 +231,13 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   neutrinos:
     strategy:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -269,13 +261,12 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   con-to-prim-tabulated:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -313,13 +304,12 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   code-failure:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -345,7 +335,6 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   induction-interpolators:
     strategy:
@@ -353,7 +342,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -382,13 +371,12 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   induction-flux:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -415,4 +403,3 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/github-actions-MacOS-gcc.yml
+++ b/.github/workflows/github-actions-MacOS-gcc.yml
@@ -37,6 +37,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   c2p-routines:
     strategy:
@@ -68,6 +69,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   c2p-failure:
     strategy:
@@ -93,6 +95,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   tabulated-eos:
     strategy:
@@ -119,6 +122,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   piecewise-polytrope-eos:
     strategy:
@@ -143,6 +147,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   grhayl-core:
     strategy:
@@ -170,6 +175,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   flux:
     strategy:
@@ -201,6 +207,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   reconstruction:
     strategy:
@@ -231,6 +238,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   neutrinos:
     strategy:
@@ -261,6 +269,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   con-to-prim-tabulated:
     strategy:
@@ -304,6 +313,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   code-failure:
     strategy:
@@ -335,6 +345,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   induction-interpolators:
     strategy:
@@ -371,6 +382,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   induction-flux:
     strategy:
@@ -403,3 +415,4 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/github-actions-Ubuntu-gcc.yml
+++ b/.github/workflows/github-actions-Ubuntu-gcc.yml
@@ -37,6 +37,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   c2p-routines:
     strategy:
@@ -68,6 +69,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   c2p-failure:
     strategy:
@@ -93,6 +95,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   tabulated-eos:
     strategy:
@@ -119,6 +122,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   piecewise-polytrope-eos:
     strategy:
@@ -143,6 +147,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   grhayl-core:
     strategy:
@@ -170,6 +175,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   flux:
     strategy:
@@ -201,6 +207,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   reconstruction:
     strategy:
@@ -231,6 +238,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   neutrinos:
     strategy:
@@ -263,6 +271,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   con-to-prim-tabulated:
     strategy:
@@ -308,6 +317,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   code-failure:
     strategy:
@@ -340,6 +350,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   induction-interpolators:
     strategy:
@@ -377,6 +388,7 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   induction-flux:
     strategy:
@@ -410,3 +422,4 @@ jobs:
         uses: ./.github/actions/code-coverage
         with:
           compiler: 'gcc'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
v4 only gives warnings, not errors, for failed uploads. Previous 'fix' doesn't properly upload to codecov.