### PR TITLE
Fix finding HDF5 shared library when multiple may exist

### DIFF
--- a/configure
+++ b/configure
@@ -322,14 +322,9 @@ NL='
 '
 probe_file()
 {
-    # Source: https://stackoverflow.com/questions/10346816
-    tmp_=$(find $1 2>/dev/null | grep -F $2)
-    # Source: https://unix.stackexchange.com/questions/276834
-    case $tmp_ in
-             "") return 1;;
-        *"$NL"*) return 2;;
-              *) return 0;;
-    esac
+    # Source: https://serverfault.com/questions/225798/
+    tmp_=$(find $1 -name "$2" 2>/dev/null | grep .)
+    return $?
 }
 
 set_hdf5()


### PR DESCRIPTION
A standard installation of HDF5 will often result in multiple shared libraries being built, e.g.:
```
lib/libhdf5.so
lib/libhdf5.so.310
lib/libhdf5.so.310.3.0
```
Where `libhdf5.so` is simply a symbolic link to the latest version.  In the current implementation of `probe_file`, the search of `libhdf5.so` will often result in multiple files being found, which results in a return status of `2`, meaning it will be considered not found and a check for the static library `libhdf5.a` will be checked for next.

This PR replaces `probe_file` by explicitly searching for the shared library filename.  The added `grep` statement will return `0` if the file is found or `1` otherwise.