### PR TITLE
CI: Updating workflows to use available Ubuntu runners

### DIFF
--- a/.github/workflows/github-actions-Ubuntu-gcc.yml
+++ b/.github/workflows/github-actions-Ubuntu-gcc.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -210,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -240,7 +240,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -271,7 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -316,7 +316,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -350,7 +350,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -385,7 +385,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/github-actions-Ubuntu-intel.yml
+++ b/.github/workflows/github-actions-Ubuntu-intel.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -210,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -240,7 +240,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -271,7 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -316,7 +316,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -350,7 +350,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -385,7 +385,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Ubuntu 20.04 will no longer be unsupported by GitHub Actions (to be removed April 1, 2025); swapped from Ubuntu 20 and 22 to 22 and ubuntu-latest.