### PR TITLE
Codecov fix

### DIFF
--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -44,4 +44,4 @@ runs:
         gcovr -r . --gcov-executable "llvm-cov-14 gcov" --keep
       shell: bash
 
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Ubuntu-clang](https://github.com/GRHayL/GRHayL/actions/workflows/github-actions-Ubuntu-clang.yml/badge.svg)](https://github.com/GRHayL/GRHayL/actions/workflows/github-actions-Ubuntu-clang.yml)
 [![MacOS-gcc](https://github.com/GRHayL/GRHayL/actions/workflows/github-actions-MacOS-gcc.yml/badge.svg)](https://github.com/GRHayL/GRHayL/actions/workflows/github-actions-MacOS-gcc.yml)
 [![MacOS-clang](https://github.com/GRHayL/GRHayL/actions/workflows/github-actions-MacOS-clang.yml/badge.svg)](https://github.com/GRHayL/GRHayL/actions/workflows/github-actions-MacOS-clang.yml)
-<!---[![codecov](https://codecov.io/gh/GRHayL/GRHayL/branch/main/graph/badge.svg)](https://codecov.io/gh/GRHayL/GRHayL)-->
+[![codecov](https://codecov.io/gh/GRHayL/GRHayL/branch/main/graph/badge.svg)](https://codecov.io/gh/GRHayL/GRHayL)
 
 The General Relativistic Hydrodynamic Library (GRHayL) is an infrastructure-agnostic
 magnetohydrodynamics code library designed for modular development of GRMHD code.

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,7 +16,7 @@ coverage:
 
 ignore:
   - "Unit_Tests"
-  - "GRHayL/include/unit_tests.h"
+  - "GRHayL/include/ghl_unit_tests.h"
   - "GRHayL/include/ghl_debug.h"
   - "GRHayL/Con2Prim/toms748.c"
 


### PR DESCRIPTION
- Changed to CodeCov v5 for full support for tokenless upload.
- Fixed codecov ignores, as a file had changed names since last upload
- Reactivated coverage % badge