### PR TITLE
C++ fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file,
+# use spaces for indentation, and indent with 4 spaces
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.{c,h,cc,hh}]
+indent_size = 2

--- a/GRHayL/Con2Prim/Hybrid/Font1D/hybrid_Font1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Font1D/hybrid_Font1D.c
@@ -61,7 +61,7 @@ ghl_error_codes_t ghl_hybrid_Font1D(
 
     const int maxits = 300;
     double tol = 1.e-15;
-    int error;
+    ghl_error_codes_t error = ghl_success;
     const int Font1D_attempts = 5;
     for(int n=0; n<Font1D_attempts; n++) {
       const int loop_maxits = maxits + n*50; // From 300 to 500 for 5 iterations
@@ -70,12 +70,12 @@ ghl_error_codes_t ghl_hybrid_Font1D(
             eos, loop_maxits, loop_tol, W0, Sf20, Psim6,
             sdots, BdotS2, B2, cons, rhob0, &rhob);
       rhob0 = rhob;
-      if(!error) break;
+      if(error == ghl_success) break;
     }
 
     //****************************************************************
 
-    if(error)
+    if(error != ghl_success)
       return error;
 
     /* First compute P_cold, eps_cold, then h = h_cold */

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D.c
@@ -46,9 +46,11 @@ ghl_error_codes_t ghl_hybrid_Noble1D(
   harm_aux_vars_struct harm_aux;
 
   // Calculate Z:
-  if( ghl_initialize_Noble(params, eos, ADM_metric, metric_aux, cons_undens,
-                           prims, &harm_aux, &gnr_out[0]) )
-    return 1;
+  ghl_error_codes_t error = ghl_initialize_Noble(
+        params, eos, ADM_metric, metric_aux, cons_undens,
+        prims, &harm_aux, &gnr_out[0]);
+  if(error)
+    return error;
 
   // To be consistent with entropy variants, unused argument 0.0 is needed
   const ghl_error_codes_t retval = ghl_general_newton_raphson(eos, &harm_aux, 1, 0.0, gnr_out, ghl_validate_1D, ghl_func_1D);
@@ -59,7 +61,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D(
   if(retval != 0) {
     return retval;
   } else if(Z <= 0. || Z > 1e20) {
-    return 4;
+    return ghl_error_invalid_Z;
   }
 
   // Calculate v^2:

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy.c
@@ -46,9 +46,11 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
   harm_aux_vars_struct harm_aux;
 
   double rho0, Z_last;
-  if( ghl_initialize_Noble_entropy(params, eos, ADM_metric, metric_aux,
-                                   cons_undens, prims, &harm_aux, &rho0, &Z_last) )
-    return 1;
+  ghl_error_codes_t error = ghl_initialize_Noble_entropy(
+        params, eos, ADM_metric, metric_aux, cons_undens,
+        prims, &harm_aux, &rho0, &Z_last);
+  if(error)
+    return error;
 
   // Make sure that Z is large enough so that v^2 < 1 :
   int i_increase = 0;
@@ -69,7 +71,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
   if(retval != 0) {
     return retval;
   } else if(Z <= 0. || Z > 1e20) {
-    return 4;
+    return ghl_error_invalid_Z;
   }
 
   const int n_iter = harm_aux.n_iter;

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble2D/hybrid_Noble2D.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble2D/hybrid_Noble2D.c
@@ -46,9 +46,11 @@ ghl_error_codes_t ghl_hybrid_Noble2D(
   harm_aux_vars_struct harm_aux;
 
   // Calculate Z and vsq:
-  if( ghl_initialize_Noble(params, eos, ADM_metric, metric_aux, cons_undens,
-                           prims, &harm_aux, &gnr_out[0]) )
-    return 1;
+  ghl_error_codes_t error = ghl_initialize_Noble(
+        params, eos, ADM_metric, metric_aux, cons_undens,
+        prims, &harm_aux, &gnr_out[0]);
+  if(error)
+    return error;
 
   gnr_out[1] = fabs(ghl_vsq_calc(&harm_aux, gnr_out[0]));
   gnr_out[1] = (gnr_out[1] > 1.0) ? (1.0 - 1.e-15) : gnr_out[1];
@@ -62,7 +64,7 @@ ghl_error_codes_t ghl_hybrid_Noble2D(
   if(retval != 0) {
     return retval;
   } else if(Z <= 0. || Z > 1e20) {
-    return 4;
+    return ghl_error_invalid_Z;
   }
 
   // Calculate v^2:

--- a/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
@@ -1,6 +1,6 @@
 #include "../../utils_Noble.h"
 
-int ghl_initialize_Noble(
+ghl_error_codes_t ghl_initialize_Noble(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,
@@ -57,7 +57,7 @@ int ghl_initialize_Noble(
   if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
     utsq = fabs(utsq);
   } else if(utsq < 0.0 || utsq > 10.0) {
-    return 1;
+    return ghl_error_invalid_utsq;
   }
 
   const double Wsq = 1.0 + utsq;   // Lorentz factor squared
@@ -82,10 +82,10 @@ int ghl_initialize_Noble(
     i_increase++;
   }
   *Z_ptr = Z_last;
-  return 0;
+  return ghl_success;
 }
 
-int ghl_initialize_Noble_entropy(
+ghl_error_codes_t ghl_initialize_Noble_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,
@@ -145,7 +145,7 @@ int ghl_initialize_Noble_entropy(
   if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
     utsq = fabs(utsq);
   } else if(utsq < 0.0 || utsq > 10.0) {
-    return 1;
+    return ghl_error_invalid_utsq;
   }
 
   const double Wsq = 1.0 + utsq;   // Lorentz factor squared
@@ -173,5 +173,5 @@ int ghl_initialize_Noble_entropy(
 
   *rho_ptr = rho0;
   *Z_ptr = w*Wsq;
-  return 0;
+  return ghl_success;
 }

--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_energy.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_energy.c
@@ -31,7 +31,7 @@ compute_rho_P_eps_W_energy(
       double *restrict W_ptr) {
 
   // Step 1: First compute rho and W
-  double rho, W;
+  double W;
   compute_rho_W_from_x_and_conservatives(x, params, cons_undens, fparams, &prims->rho, &W);
 
   // Step 2: Compute eps

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
@@ -59,7 +59,7 @@ static ghl_error_codes_t ghl_newman_energy(
     double a = e + xprs + 0.5*B_squared;
 
     // Eq. (5.9) of Newman & Hamlin 2014
-    if(d > 4.0*a*a*a/27.0) return 1;
+    if(d > 4.0*a*a*a/27.0) return ghl_error_newman_invalid_discriminant;
 
     // phi = acos( sqrt(27d/4a^{3}) ) (eq. 5.10 in Newman & Hamlin 2014)
     double phi = acos( sqrt(27.0*d/(4.0*a*a*a)) );

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
@@ -54,7 +54,7 @@ static ghl_error_codes_t ghl_newman_entropy(
     double a = e + xprs + 0.5*B_squared;
 
     // Eq. (5.9) of Newman & Hamlin 2014
-    if(d > 4.0*a*a*a/27.0) return 1;
+    if(d > 4.0*a*a*a/27.0) return ghl_error_newman_invalid_discriminant;
 
     // phi = acos( sqrt(27d/4a^{3}) ) (eq. 5.10 in Newman & Hamlin 2014)
     double phi = acos( sqrt(27.0*d/(4.0*a*a*a)) );

--- a/GRHayL/Con2Prim/enforce_primitive_limits_and_compute_u0.c
+++ b/GRHayL/Con2Prim/enforce_primitive_limits_and_compute_u0.c
@@ -16,6 +16,7 @@ ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
   // Hybrid EOS specific floors and ceilings
   switch(eos->eos_type) {
     case ghl_eos_hybrid:
+    {
       // Apply floors and ceilings to rho
       prims->rho = MIN(MAX(prims->rho, eos->rho_min), eos->rho_max);
 
@@ -46,6 +47,7 @@ ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
         prims->entropy = ghl_hybrid_compute_entropy_function(eos, prims->rho, prims->press);
       }
       break;
+    }
 
     // Tabulated EOS specific floors and ceilings
     case ghl_eos_tabulated:

--- a/GRHayL/Con2Prim/get_con2prim_routine_name.c
+++ b/GRHayL/Con2Prim/get_con2prim_routine_name.c
@@ -1,6 +1,6 @@
 #include "ghl.h"
 
-char *ghl_get_con2prim_routine_name(const ghl_con2prim_method_t key) {
+const char *ghl_get_con2prim_routine_name(const ghl_con2prim_method_t key) {
   switch(key) {
     case None:
       return "None";

--- a/GRHayL/Con2Prim/utils_Noble.h
+++ b/GRHayL/Con2Prim/utils_Noble.h
@@ -192,7 +192,7 @@ void ghl_func_2D(
       double *restrict f,
       double *restrict df);
 
-int ghl_initialize_Noble(
+ghl_error_codes_t ghl_initialize_Noble(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,
@@ -202,7 +202,7 @@ int ghl_initialize_Noble(
       harm_aux_vars_struct *restrict harm_aux,
       double *restrict Z_ptr);
 
-int ghl_initialize_Noble_entropy(
+ghl_error_codes_t ghl_initialize_Noble_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps.c
@@ -20,7 +20,7 @@ ghl_error_codes_t NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps(
 
   // Step 3: Perform the interpolation
   const double root_finding_precision = eos->root_finding_precision;
-  const int error = NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities(eos, 3, root_finding_precision,
+  const ghl_error_codes_t error = NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities(eos, 3, root_finding_precision,
                                                                                 rho, Y_e, eps, NRPyEOS_eps_key,
                                                                                 keys, outvars, T);
 

--- a/GRHayL/GRHayL_Core/read_error_codes.c
+++ b/GRHayL/GRHayL_Core/read_error_codes.c
@@ -60,5 +60,14 @@ void ghl_read_error_codes(
     case ghl_error_table_neg_energy:
       ghl_abort("While interpolating temperature, found eps+energy_shift < 0.0. Interpolation cannot be performed.\n");
       break;
+    case ghl_error_invalid_utsq:
+      ghl_abort("While computing u^0 squared in Con2Prim, found an invalid value (<0 or >>1)");
+      break;
+    case ghl_error_invalid_Z:
+      ghl_abort("While computing Z in Con2Prim, found an invalid value (<0 or >>1)");
+      break;
+    case ghl_error_newman_invalid_discriminant:
+      ghl_abort("Found negative discriminant inside Newman1D Con2Prim");
+      break;
   }
 }

--- a/GRHayL/include/ghl.h
+++ b/GRHayL/include/ghl.h
@@ -48,7 +48,10 @@ typedef enum {
   ghl_error_exceed_table_vars,
   ghl_error_table_neg_energy,
   ghl_error_table_bisection,
-  ghl_error_u0_singular
+  ghl_error_u0_singular,
+  ghl_error_invalid_utsq,
+  ghl_error_invalid_Z,
+  ghl_error_newman_invalid_discriminant,
 } ghl_error_codes_t;
 
 typedef enum {
@@ -263,7 +266,7 @@ typedef struct ghl_eos_parameters {
 extern "C" {
 #endif
 
-char *ghl_get_con2prim_routine_name(const ghl_con2prim_method_t key);
+const char *ghl_get_con2prim_routine_name(const ghl_con2prim_method_t key);
 
 void ghl_initialize_eos_functions(
     const ghl_eos_t eos_type);

--- a/GRHayL/include/ghl.h
+++ b/GRHayL/include/ghl.h
@@ -27,6 +27,7 @@
 #ifndef restrict
 #define restrict __restrict__
 #endif
+extern "C" {
 #endif
 
 typedef enum {
@@ -69,7 +70,11 @@ typedef enum {
   Newman1D_entropy
 } ghl_con2prim_method_t;
 
-typedef enum {ghl_eos_simple, ghl_eos_hybrid, ghl_eos_tabulated} ghl_eos_t;
+typedef enum {
+  ghl_eos_simple,
+  ghl_eos_hybrid,
+  ghl_eos_tabulated
+} ghl_eos_t;
 
 /*
  * Struct        : ghl_parameters
@@ -261,10 +266,6 @@ typedef struct ghl_eos_parameters {
   //------------------------------------------------
 
 } ghl_eos_parameters;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 const char *ghl_get_con2prim_routine_name(const ghl_con2prim_method_t key);
 

--- a/GRHayL/include/ghl_con2prim.h
+++ b/GRHayL/include/ghl_con2prim.h
@@ -3,6 +3,9 @@
 
 #include "ghl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 //------------- Con2Prim struct --------------------
 /*
    The struct ghl_con2prim_diagnostics contains variables for error-checking and
@@ -36,11 +39,6 @@ typedef struct ghl_con2prim_diagnostics {
 typedef struct ghl_palenzuela_quantities {
   double q, r, s, t, D, Y_e, S;
 } ghl_palenzuela_quantities;
-
-//--------------------------------------------------
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 //--------- Initialization routines ----------------
 
@@ -87,9 +85,8 @@ void ghl_compute_conservs(
       const ghl_primitive_quantities *restrict prims,
       ghl_conservative_quantities *restrict cons);
 
-//--------------------------------------------------
-
 //-------------- Con2Prim routines -----------------
+
 ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
@@ -227,8 +224,6 @@ ghl_error_codes_t ghl_tabulated_Newman1D_entropy(
       ghl_primitive_quantities *restrict prim,
       ghl_con2prim_diagnostics *restrict diagnostics);
 
-//--------------------------------------------------
-
 //------------ Auxiliary Functions -----------------
 
 bool ghl_limit_utilde_and_compute_v(
@@ -236,10 +231,6 @@ bool ghl_limit_utilde_and_compute_v(
       const ghl_metric_quantities *restrict metric,
       double utU[3],
       ghl_primitive_quantities *restrict prims);
-
-#ifdef __cplusplus
-}
-#endif
 
 extern ghl_error_codes_t (*ghl_con2prim_multi_method)(
       const ghl_parameters *restrict params,
@@ -249,5 +240,9 @@ extern ghl_error_codes_t (*ghl_con2prim_multi_method)(
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
       ghl_con2prim_diagnostics *restrict diagnostics);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // GHL_CON2PRIM_H

--- a/GRHayL/include/ghl_debug.h
+++ b/GRHayL/include/ghl_debug.h
@@ -22,6 +22,10 @@
           _indent_1(f), "", _indent_2(f), f,                                     \
           _indent_1(g), "", _indent_2(g), g);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void ghl_debug_print_prims(
       const ghl_primitive_quantities *restrict p) {
 
@@ -47,6 +51,10 @@ static inline void ghl_debug_print_cons(
 ".------------------------.------------------------.------------------------.------------------------.------------------------.------------------------.------------------------.\n\n",
           c->tau, c->SD[0], c->SD[1], c->SD[2], c->rho, c->entropy, c->Y_e);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #define ghl_debug_print_primitives(p) {                                \
   fprintf(stderr, "DEBUG (Primitive Quantities) func: %s, line: %d\n", \

--- a/GRHayL/include/ghl_eos_functions.h
+++ b/GRHayL/include/ghl_eos_functions.h
@@ -1,6 +1,10 @@
 #ifndef GHL_EOS_FUNCTIONS_H_
 #define GHL_EOS_FUNCTIONS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern ghl_error_codes_t (*ghl_compute_h_and_cs2)(
       const ghl_eos_parameters *restrict eos,
       ghl_primitive_quantities *restrict prims,
@@ -297,5 +301,9 @@ extern void (*ghl_tabulated_enforce_bounds_rho_Ye_P)(
       double *restrict rho,
       double *restrict Y_e,
       double *restrict P );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // GHL_EOS_FUNCTIONS_H_

--- a/GRHayL/include/ghl_eos_functions_declaration.h
+++ b/GRHayL/include/ghl_eos_functions_declaration.h
@@ -1,6 +1,10 @@
 #ifndef GHL_EOS_FUNCTIONS_DECLARATION_H_
 #define GHL_EOS_FUNCTIONS_DECLARATION_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 ghl_error_codes_t (*ghl_compute_h_and_cs2)(
       const ghl_eos_parameters *restrict eos,
       ghl_primitive_quantities *restrict prims,
@@ -296,5 +300,9 @@ void (*ghl_tabulated_enforce_bounds_rho_Ye_P)(
       double *restrict rho,
       double *restrict Y_e,
       double *restrict P );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // GHL_EOS_FUNCTIONS_DECLARATION_H_

--- a/GRHayL/include/ghl_flux_source.h
+++ b/GRHayL/include/ghl_flux_source.h
@@ -3,7 +3,6 @@
 
 #include "ghl.h"
 
-
 static const double TINYDOUBLE = 1e-100;
 
 static const double SQRT_4_PI = 1; //3.544907701811032054596334966682290365L;

--- a/GRHayL/include/ghl_induction.h
+++ b/GRHayL/include/ghl_induction.h
@@ -3,6 +3,12 @@
 
 #include "ghl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//------------------ Structs ---------------------
+//
 typedef struct ghl_HLL_vars {
   double B1r, B1l;
   double B2r, B2l;
@@ -20,10 +26,6 @@ typedef struct ghl_induction_interp_vars {
 } ghl_induction_interp_vars;
 
 //------------------ Functions ---------------------
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 double ghl_HLL_flux_with_B(
       const double psi6,

--- a/GRHayL/include/ghl_io.h
+++ b/GRHayL/include/ghl_io.h
@@ -5,6 +5,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ghl_info(const char *format, ...);
 
 void ghl_Warn_Error(
@@ -31,5 +35,9 @@ typedef enum  {
 
 #define ghl_Error(exit_code, ...) \
   ghl_Warn_Error("Error", exit_code, __FILE__, __LINE__, __func__, __VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // GHL_IO_H_

--- a/GRHayL/include/ghl_metric_helpers.h
+++ b/GRHayL/include/ghl_metric_helpers.h
@@ -1,6 +1,10 @@
 #ifndef GHL_METRIC_HELPERS_H_
 #define GHL_METRIC_HELPERS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void ghl_raise_lower_vector_4D(
       const double g4[][4],
       const double vec[4],
@@ -8,13 +12,13 @@ static inline void ghl_raise_lower_vector_4D(
 
   vec_inv[0] = g4[0][0] * vec[0] + g4[0][1] * vec[1]
              + g4[0][2] * vec[2] + g4[0][3] * vec[3];
-                                                     
+
   vec_inv[1] = g4[0][1] * vec[0] + g4[1][1] * vec[1]
              + g4[1][2] * vec[2] + g4[1][3] * vec[3];
-                                                     
+
   vec_inv[2] = g4[0][2] * vec[0] + g4[1][2] * vec[1]
              + g4[2][2] * vec[2] + g4[2][3] * vec[3];
-                                                     
+
   vec_inv[3] = g4[0][3] * vec[0] + g4[1][3] * vec[1]
              + g4[2][3] * vec[2] + g4[3][3] * vec[3];
 }
@@ -27,11 +31,11 @@ static inline void ghl_raise_lower_vector_3D(
   vec_inv[0] = gamma[0][0] * vec[0]
              + gamma[0][1] * vec[1]
              + gamma[0][2] * vec[2];
-                                    
+
   vec_inv[1] = gamma[0][1] * vec[0]
              + gamma[1][1] * vec[1]
              + gamma[1][2] * vec[2];
-                                    
+
   vec_inv[2] = gamma[0][2] * vec[0]
              + gamma[1][2] * vec[1]
              + gamma[2][2] * vec[2];
@@ -64,5 +68,9 @@ static inline double ghl_compute_vec2_from_vec3D(
                  gamma[0][2] * vec[0] * vec[2] +
                  gamma[1][2] * vec[1] * vec[2]));
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // GHL_METRIC_HELPERS_H

--- a/GRHayL/include/ghl_radiation.h
+++ b/GRHayL/include/ghl_radiation.h
@@ -3,6 +3,10 @@
 
 #include "ghl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Neutrino quantities
 typedef struct ghl_neutrino_luminosities {
   double nue, anue, nux;
@@ -13,6 +17,10 @@ typedef struct ghl_neutrino_opacities {
 } ghl_neutrino_opacities;
 
 typedef ghl_neutrino_opacities ghl_neutrino_optical_depths;
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "nrpyleakage.h"
 

--- a/GRHayL/include/ghl_reconstruction.h
+++ b/GRHayL/include/ghl_reconstruction.h
@@ -3,16 +3,16 @@
 
 #include "ghl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Integer constants to keep track of stencil.
 enum reconstruction_stencil {
   MINUS2, MINUS1,
   PLUS_0, PLUS_1,
   PLUS_2
 };
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 // PPM functions
 void ghl_ppm_reconstruction(

--- a/GRHayL/include/ghl_unit_tests.h
+++ b/GRHayL/include/ghl_unit_tests.h
@@ -10,6 +10,10 @@
 #include "nrpyeos_tabulated.h"
 #include "nrpyeos_hybrid.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ghl_test_compute_A_flux_with_B(
       const int dirlength,
       const int A_dir,
@@ -77,7 +81,7 @@ void ghl_test_compute_ccc_ADM(
       double *restrict sqrtg_Ax_interp,
       double *restrict sqrtg_Ay_interp,
       double *restrict sqrtg_Az_interp);
-    
+
 void ghl_test_compute_vvv_ADM(
       const int dirlength,
       const double *restrict lapse,
@@ -334,4 +338,9 @@ fopen_with_check(const char *filename, const char *mode) {
   if(!fp) ghl_error("Could not open file %s.\n", filename);
   return fp;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif // GHL_UNIT_TESTS_H_

--- a/GRHayL/include/nrpyeos_tabulated.h
+++ b/GRHayL/include/nrpyeos_tabulated.h
@@ -1,6 +1,8 @@
 #ifndef NRPYEOS_TABULATED_H_
 #define NRPYEOS_TABULATED_H_
+
 #include "ghl.h"
+
 #ifndef GRHAYL_USE_HDF5
 #define HDF5_ERROR_IF_USED \
   ghl_error("HDF5 is disabled, so this function cannot be used\n")
@@ -8,7 +10,22 @@
 
 #include <string.h>
 #include <hdf5.h>
+
 #define H5_USE_16_API 1
+
+// Unit conversion
+#define CODE_TO_CGS_DENSITY  6.17714470405638e+17 // [Density]    = M_sun / L^3
+#define CODE_TO_CGS_ENERGY   8.98755178736818e+20 // [Energy]     = c^2
+#define CODE_TO_CGS_PRESSURE 5.55174079257738e+38 // [Pressure]   = M_sun / (L T^2)
+#define CGS_TO_CODE_LENGTH   6.77269222552442e-06 // 1/[Length]   = c^2 / (G M_sun)
+#define CGS_TO_CODE_TIME     2.03040204956746e+05 // 1/[Time]     = c / L
+#define CGS_TO_CODE_DENSITY  1.61887093132742e-18 // 1/[Density]  = L^3 / M_sun
+#define CGS_TO_CODE_PRESSURE 1.80123683248503e-39 // 1/[Pressure] = (L T^2) / M_sun
+#define CGS_TO_CODE_ENERGY   1.11265005605362e-21 // 1/[Energy]   = 1 / c^2
+//
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // Table keys
 enum eos_keys {
@@ -21,16 +38,6 @@ enum eos_keys {
   NRPyEOS_Gamma_key, NRPyEOS_ntablekeys
 };
 
-// Unit conversion
-#define CODE_TO_CGS_DENSITY  6.17714470405638e+17 // [Density]    = M_sun / L^3
-#define CODE_TO_CGS_ENERGY   8.98755178736818e+20 // [Energy]     = c^2
-#define CODE_TO_CGS_PRESSURE 5.55174079257738e+38 // [Pressure]   = M_sun / (L T^2)
-#define CGS_TO_CODE_LENGTH   6.77269222552442e-06 // 1/[Length]   = c^2 / (G M_sun)
-#define CGS_TO_CODE_TIME     2.03040204956746e+05 // 1/[Time]     = c / L
-#define CGS_TO_CODE_DENSITY  1.61887093132742e-18 // 1/[Density]  = L^3 / M_sun
-#define CGS_TO_CODE_PRESSURE 1.80123683248503e-39 // 1/[Pressure] = (L T^2) / M_sun
-#define CGS_TO_CODE_ENERGY   1.11265005605362e-21 // 1/[Energy]   = 1 / c^2
-
 // Name of the variables. This is only used to print
 // information about the keys during startup
 static const char table_var_names[NRPyEOS_ntablekeys][10] = {
@@ -40,10 +47,6 @@ static const char table_var_names[NRPyEOS_ntablekeys][10] = {
 };
 //********************************************
 #endif // GRHAYL_USE_HDF5
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 // Function prototypes
 void NRPyEOS_read_table_set_EOS_params(
@@ -315,4 +318,5 @@ void NRPyEOS_enforce_table_bounds_rho_Ye_P(
 #ifdef __cplusplus
 }
 #endif
+
 #endif // NRPYEOS_TABULATED_H_

--- a/GRHayL/include/nrpyleakage.h
+++ b/GRHayL/include/nrpyleakage.h
@@ -63,6 +63,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 // Function prototypes
 double NRPyLeakage_Fermi_Dirac_integrals(const int k, const double z);
 

--- a/Unit_Tests/unit_test_hybrid_failure.c
+++ b/Unit_Tests/unit_test_hybrid_failure.c
@@ -4,7 +4,7 @@ int main(int argc, char **argv) {
   const int arraylength = 3;
 
   ghl_error_codes_t *expected_errors = (ghl_error_codes_t*) malloc(sizeof(ghl_error_codes_t)*arraylength);
-  expected_errors[0] = 1;
+  expected_errors[0] = ghl_error_invalid_utsq;
   expected_errors[1] = ghl_error_c2p_max_iter;
   expected_errors[2] = ghl_error_c2p_singular;
 


### PR DESCRIPTION
This PR adds several small fixes that would either prevent code from being accessed from a C++ project (worrisome) or prevent it from being compiled with a C++ compiler (less so).

Changes include:
1) Adding missing `extern "C" { ... }` guards to headers;
2) Changing the type of functions that return string literals from `char *` to `const char *`; and
3) Fixing all instances where magic numbers (literal integers) are returned as error codes.

Code now compiles without errors or warnings with both C and C++ compilers.

I also added a very basic .editorconfig file to the repo, which helps maintain consistency while editing files with different text editors/IDEs.